### PR TITLE
Fix towns field and restore primary town

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
@@ -57,8 +57,12 @@ import java.util.stream.Collectors;
 public class Resident extends TownyObject implements InviteReceiver, EconomyHandler, TownBlockOwner, Identifiable, ForwardingAudience.Single {
 	private List<Resident> friends = new ArrayList<>();
 	// private List<Object[][][]> regenUndo = new ArrayList<>(); // Feature is disabled as of MC 1.13, maybe it'll come back.
-	private UUID uuid = null;
-	private List<Town> towns = new ArrayList<>()
+       private UUID uuid = null;
+       /**
+        * Primary town membership.
+        */
+       private Town town = null;
+       private List<Town> towns = new ArrayList<>();
 	private long lastOnline;
 	private long registered;
 	private long joinedTownAt;


### PR DESCRIPTION
## Summary
- fix missing semicolon on the towns field
- reintroduce the `town` field for a primary town reference

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876a58da7f0832990f93d7ae7207bb7