### PR TITLE
Introduce primary town getters

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAPI.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAPI.java
@@ -73,8 +73,8 @@ public class TownyAPI {
     	if (resident == null)
     		return null;
     	
-        if (resident.hasTown())
-			return resident.getTownOrNull().getSpawnOrNull();
+       if (resident.hasTown())
+                       return resident.getPrimaryTown().getSpawnOrNull();
 
 		return null;
     }
@@ -102,7 +102,7 @@ public class TownyAPI {
      */
     @Nullable
     public Town getResidentTownOrNull(Resident resident) {
-    	return resident.getTownOrNull();
+       return resident.getPrimaryTown();
     }
     
     /**
@@ -113,8 +113,8 @@ public class TownyAPI {
      */
     @Nullable
     public Nation getResidentNationOrNull(Resident resident) {
-    	if (resident.hasNation())
-    		return resident.getTownOrNull().getNationOrNull();
+       if (resident.hasNation())
+               return resident.getPrimaryTown().getNationOrNull();
     	return null;
     }
     
@@ -898,7 +898,7 @@ public class TownyAPI {
 	public Town getTown(@NotNull Player player) {
 		Resident resident = getResident(player);
 		
-		return resident == null ? null : resident.getTownOrNull();
+               return resident == null ? null : resident.getPrimaryTown();
 	}
 	
 	@Nullable
@@ -922,7 +922,7 @@ public class TownyAPI {
 		final boolean isMayor = resident.hasPermissionNode(PermissionNodes.TOWNY_COMMAND_PLOT_ASMAYOR.getNode());
 
 		if (townBlock.hasResident()) {
-			final boolean isMayorInTheirOwnTown = isMayor && resident.hasTown() && resident.getTownOrNull() == townBlock.getTownOrNull();
+                       final boolean isMayorInTheirOwnTown = isMayor && resident.hasTown() && resident.getTowns().contains(townBlock.getTownOrNull());
 			// Resident is either an admin, or the mayor (or equivalent) of the townblock, or the townblock's actual owner.
 			if (isAdmin || isMayorInTheirOwnTown || townBlock.hasResident(resident))
 				return;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyMessaging.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyMessaging.java
@@ -927,7 +927,7 @@ public class TownyMessaging {
 	 * @param message The translatable message to be sent to the resident and/or their town.
 	 */
 	public static void sendPrefixedTownMessage(Resident resident, Translatable message) {
-		Town town = resident.getTownOrNull();
+               Town town = resident.getPrimaryTown();
 		
 		if (town == null)
 			sendMsg(resident, message);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -1120,9 +1120,9 @@ public class TownySettings {
 		return resident.isKing() ? resident.getNationOrNull().getNationLevel().kingPrefix() : "";
 	}
 
-	public static String getMayorPrefix(Resident resident) {
-		return resident.isMayor() ? resident.getTownOrNull().getTownLevel().mayorPrefix() : "";
-	}
+       public static String getMayorPrefix(Resident resident) {
+               return resident.isMayor() ? resident.getPrimaryTown().getTownLevel().mayorPrefix() : "";
+       }
 
 	public static String getCapitalPostfix(Town town) {
 		return town.hasNation() ? getCapitalPostfix(town.getNationOrNull()) : "";
@@ -1184,9 +1184,9 @@ public class TownySettings {
 		return resident.isKing() ? resident.getNationOrNull().getNationLevel().kingPostfix() : "";
 	}
 
-	public static String getMayorPostfix(Resident resident) {
-		return resident.isMayor() ? resident.getTownOrNull().getTownLevel().mayorPostfix() : "";
-	}
+       public static String getMayorPostfix(Resident resident) {
+               return resident.isMayor() ? resident.getPrimaryTown().getTownLevel().mayorPostfix() : "";
+       }
 
 	public static String getNPCPrefix() {
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -412,7 +412,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		if (newSplit[0].equalsIgnoreCase("pvp")) {
 			checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_RESIDENT_TOGGLE_PVP.getNode());
 			
-			Town town = resident.getTownOrNull();
+                       Town town = resident.getPrimaryTown();
 			// Test to see if the pvp cooldown timer is active for the town this resident belongs to.
 			if (TownySettings.getPVPCoolDownTime() > 0 && town != null && !resident.isAdmin()) {
 				if (CooldownTimerTask.hasCooldown(town.getUUID().toString(), CooldownType.PVP))

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -2916,8 +2916,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 	public static void townKick(Player player, String[] names) throws TownyException {
 		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWN_KICK.getNode());
 		catchRuinedTown(player);
-		Resident resident = getResidentOrThrow(player);
-		Town town = resident.getTown();
+               Resident resident = getResidentOrThrow(player);
+               Town town = resident.getPrimaryTown();
 
 		townKickResidents(player, resident, town, ResidentUtil.getValidatedResidentsOfTown(player, town, names));
 
@@ -3960,8 +3960,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				throw new TownyException(Translatable.of("msg_err_dont_belong_town"));
 
 			// If the town is still null, the resident has to have a town.
-			if (town == null)
-				town = resident.getTownOrNull();
+                       if (town == null)
+                               town = resident.getPrimaryTown();
 
 			// Figure out how much to deposit or withdraw.
 			int amount;
@@ -4346,8 +4346,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				}
 
 				Resident currentMayor = town.getMayor();
-				if (resident.equals(currentMayor)) {
-					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_town_buytown_already_mayor", resident.getTownOrNull().getName()));
+                               if (resident.equals(currentMayor)) {
+                                       TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_town_buytown_already_mayor", resident.getPrimaryTown().getName()));
 					return;
 				}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyCommand.java
@@ -181,8 +181,8 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 					} else if (player != null) {
 						Resident resident = TownyAPI.getInstance().getResident(player);
 						
-						if (resident != null)
-							town = resident.getTownOrNull();
+                                               if (resident != null)
+                                                       town = resident.getPrimaryTown();
 					}
 
 					for (String line : getTownyPrices(town, Translator.locale(sender)))

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -315,8 +315,8 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		for (Resident toCheck : toSave)
 			saveResident(toCheck);
 		
-		if (resident.hasTown() && resident.getTownOrNull() != null)
-			resident.removeTown();
+               if (resident.hasTown() && resident.getPrimaryTown() != null)
+                       resident.removeTown();
 
 		if (resident.hasUUID() && !resident.isNPC())
 			saveHibernatedResident(resident.getUUID(), resident.getRegistered());
@@ -851,9 +851,9 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 				saveTownBlock(tb);				
 			}
 			
-			// Save the town if the player was the mayor.
-			if (resident.isMayor())
-				saveTown(resident.getTown());
+                       // Save the town if the player was the mayor.
+                       if (resident.isMayor())
+                               saveTown(resident.getPrimaryTown());
 			
 			// Make an oldResident with the previous name for use in searching friends/outlawlists/deleting the old resident file.
 			Resident oldResident = new Resident(oldName);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -2028,8 +2028,8 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		if (!TownySettings.getDefaultResidentAbout().equals(resident.getAbout()))
 			list.add("about=" + resident.getAbout());
 
-		if (resident.hasTown()) {
-			list.add("town=" + resident.getTownOrNull().getName());
+               if (resident.hasTown()) {
+                       list.add("town=" + resident.getPrimaryTown().getName());
 			list.add("town-ranks=" + StringMgmt.join(resident.getTownRanksForSaving(), ","));
 			list.add("nation-ranks=" + StringMgmt.join(resident.getNationRanksForSaving(), ","));
 		}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -2311,7 +2311,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			
 			if (!TownySettings.getDefaultResidentAbout().equals(resident.getAbout()))
 				res_hm.put("about", resident.getAbout());
-			res_hm.put("town", resident.hasTown() ? resident.getTown().getName() : "");
+                       res_hm.put("town", resident.hasTown() ? resident.getPrimaryTown().getName() : "");
 			res_hm.put("town-ranks", resident.hasTown() ? StringMgmt.join(resident.getTownRanksForSaving(), "#") : "");
 			res_hm.put("nation-ranks", resident.hasTown() ? StringMgmt.join(resident.getNationRanksForSaving(), "#") : "");
 			res_hm.put("friends", StringMgmt.join(resident.getFriends(), "#"));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/TownClaimEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/TownClaimEvent.java
@@ -64,7 +64,7 @@ public class TownClaimEvent extends Event  {
 	/**
 	 * @return the Town which claimed this TownBlock.
 	 */
-	public Town getTown() {
-		return resident.getTownOrNull();
-	}
+       public Town getTown() {
+               return resident.getPrimaryTown();
+       }
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -1076,8 +1076,8 @@ public class TownyPlayerListener implements Listener {
 		if (tb == null)
 			return keepInventory;
 
-		if (resident.hasTown() && !keepInventory) {
-			Town town = resident.getTownOrNull();
+               if (resident.hasTown() && !keepInventory) {
+                       Town town = resident.getPrimaryTown();
 			Town tbTown = tb.getTownOrNull();
 			// Sometimes we keep the inventory only when they are in their own town.
 			if (TownySettings.getKeepInventoryInOwnTown() && tbTown.equals(town))
@@ -1274,7 +1274,7 @@ public class TownyPlayerListener implements Listener {
 	}
 
 	public boolean blockWarPlayerCommand(Player player, Resident resident, String command) {
-		if (resident.hasTown() && resident.getTownOrNull().hasActiveWar() && blockedWarCommands.containsCommand(command)) {
+               if (resident.hasTown() && resident.getPrimaryTown().hasActiveWar() && blockedWarCommands.containsCommand(command)) {
 			TownyMessaging.sendErrorMsg(player, Translatable.of("msg_command_war_blocked"));
 			return true;
 		}
@@ -1341,7 +1341,7 @@ public class TownyPlayerListener implements Listener {
 			if (town.hasResident(resident) 
 				|| resident.hasPermissionNode(PermissionNodes.TOWNY_ADMIN_TOURIST_COMMAND_LIMITATION_BYPASS.getNode())
 				|| TownySettings.doTrustedResidentsBypassTownBlockedCommands() && town.hasTrustedResident(resident)
-				|| (resident.hasTown() && TownySettings.doAlliesBypassTownBlockedCommands() && CombatUtil.isAlly(town, resident.getTownOrNull())))
+                               || (resident.hasTown() && TownySettings.doAlliesBypassTownBlockedCommands() && CombatUtil.isAlly(town, resident.getPrimaryTown())))
 				return false;
 
 			TownyMessaging.sendErrorMsg(player, Translatable.of("msg_command_outsider_blocked", town.getName()));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Resident.java
@@ -273,10 +273,34 @@ public class Resident extends TownyObject implements InviteReceiver, EconomyHand
 	 * 
 	 * @return Town the resident belongs to or null.
 	 */
-	@Nullable 
-	public Town getTownOrNull() {
-		return town;
-	}
+        @Nullable
+        public Town getTownOrNull() {
+                return town;
+        }
+
+       /**
+        * Returns the resident's primary town. This currently mirrors
+        * {@link #getTownOrNull()} until multi-town membership is
+        * fully implemented.
+        *
+        * @return the resident's primary town or {@code null}.
+        */
+       @Nullable
+       public Town getPrimaryTown() {
+               return getTownOrNull();
+       }
+
+       /**
+        * Returns a list of towns this resident belongs to. This method
+        * currently returns a single-item list containing the resident's
+        * primary town if they have one.
+        *
+        * @return list of towns the resident is a member of.
+        */
+       public List<Town> getTowns() {
+               Town primaryTown = getTownOrNull();
+               return primaryTown == null ? Collections.emptyList() : Collections.singletonList(primaryTown);
+       }
 
 	public void setTown(Town town) throws AlreadyRegisteredException {
 		setTown(town, true);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -417,9 +417,9 @@ public class Town extends Government implements TownBlockOwner {
 		if (hasResident(resident))
 			throw new AlreadyRegisteredException(Translation.of("msg_err_already_in_town", resident.getName(), getFormattedName()));
 		
-		final Town residentTown = resident.getTownOrNull();
-		if (residentTown != null && !this.equals(residentTown))
-			throw new AlreadyRegisteredException(Translation.of("msg_err_already_in_town", resident.getName(), residentTown.getFormattedName()));
+               final Town residentTown = resident.getPrimaryTown();
+               if (residentTown != null && !this.equals(residentTown))
+                       throw new AlreadyRegisteredException(Translation.of("msg_err_already_in_town", resident.getName(), residentTown.getFormattedName()));
 	}
 
 	public boolean isMayor(Resident resident) {
@@ -1253,9 +1253,9 @@ public class Town extends Government implements TownBlockOwner {
 		if (hasOutlaw(resident))
 			throw new AlreadyRegisteredException(Translation.of("msg_err_resident_already_an_outlaw"));
 		
-		final Town residentTown = resident.getTownOrNull();
-		if (this.equals(residentTown))
-			throw new AlreadyRegisteredException(Translation.of("msg_err_not_outlaw_in_your_town"));
+               final Town residentTown = resident.getPrimaryTown();
+               if (this.equals(residentTown))
+                       throw new AlreadyRegisteredException(Translation.of("msg_err_not_outlaw_in_your_town"));
 	}
 	
 	public void removeOutlaw(Resident resident) {
@@ -1675,8 +1675,7 @@ public class Town extends Government implements TownBlockOwner {
 	}
 	
 	public boolean hasTrustedResident(Resident resident) {
-		Town residentsTown = resident.getTownOrNull();
-		return trustedResidents.contains(resident) || (residentsTown != null && this.hasTrustedTown(residentsTown));
+               return trustedResidents.contains(resident) || resident.getTowns().stream().anyMatch(this::hasTrustedTown);
 	}
 	
 	public void addTrustedResident(Resident resident) {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlock.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlock.java
@@ -653,9 +653,9 @@ public class TownBlock extends TownyObject {
 				|| (!hasMinTownMembershipDays() && !hasMaxTownMembershipDays()))
 			return;
 
-		Town residentTown = resident.getTownOrNull();
-		if (residentTown == null || !residentTown.equals(this.town))
-			return;
+               boolean isResidentOfTown = resident.getTowns().contains(this.town);
+               if (!isResidentOfTown)
+                       return;
 
 		long joinDate = resident.getJoinedTownAt();
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
@@ -64,7 +64,7 @@ public class OnPlayerLogin implements Runnable {
 
 		TownyPerms.assignPermissions(resident, player);
 
-		final Town town = resident.getTownOrNull();
+               final Town town = resident.getPrimaryTown();
 		if (town != null) {
 			Nation nation = resident.getNationOrNull();
 

--- a/Towny/src/main/java/com/palmergames/bukkit/util/DrawSmokeTaskFactory.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/DrawSmokeTaskFactory.java
@@ -36,7 +36,7 @@ public class DrawSmokeTaskFactory {
 	}
 
 	public static Color getAffiliationColor(Resident resident, WorldCoord coord) {
-		Town residentTown = resident.getTownOrNull();
+               Town residentTown = resident.getPrimaryTown();
 		Town town = coord.getTownOrNull();
 
 		if (residentTown == null || town == null)


### PR DESCRIPTION
## Summary
- add Resident#getPrimaryTown and Resident#getTowns
- use primary-town in kick command and login handling
- save primary town names when persisting residents
- update town member checks for multi-town logic

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68769e73c7c08329a9987e111d39919f