### PR TITLE
Fix resident removal clearing all towns

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -315,8 +315,9 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		for (Resident toCheck : toSave)
 			saveResident(toCheck);
 		
-		if (resident.hasTown() && resident.getTownOrNull() != null)
-			resident.removeTown();
+               if (resident.hasTown())
+                       for (Town town : new ArrayList<>(resident.getTowns()))
+                               resident.removeTown(town);
 
 		if (resident.hasUUID() && !resident.isNPC())
 			saveHibernatedResident(resident.getUUID(), resident.getRegistered());


### PR DESCRIPTION
## Summary
- update `removeResident` to loop over all towns when clearing resident

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68769e72b7948329925758e31f010354