### PR TITLE
Remove cross-town join check

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -417,9 +417,9 @@ public class Town extends Government implements TownBlockOwner {
 		if (hasResident(resident))
 			throw new AlreadyRegisteredException(Translation.of("msg_err_already_in_town", resident.getName(), getFormattedName()));
 		
-		final Town residentTown = resident.getTownOrNull();
-		if (residentTown != null && !this.equals(residentTown))
-			throw new AlreadyRegisteredException(Translation.of("msg_err_already_in_town", resident.getName(), residentTown.getFormattedName()));
+                final Town residentTown = resident.getTownOrNull();
+                if (residentTown != null && this.equals(residentTown))
+                        throw new AlreadyRegisteredException(Translation.of("msg_err_already_in_town", resident.getName(), getFormattedName()));
 	}
 
 	public boolean isMayor(Resident resident) {


### PR DESCRIPTION
## Summary
- allow residents to join a new town even if already in another

## Testing
- `mvn -q -DskipTests=false test` *(fails: `command not found: mvn`)*

------
https://chatgpt.com/codex/tasks/task_e_68769e725e4883299476eb17e34171f2