### PR TITLE
Implement multi-town support for Resident

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAPI.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyAPI.java
@@ -74,7 +74,7 @@ public class TownyAPI {
     		return null;
     	
         if (resident.hasTown())
-			return resident.getTownOrNull().getSpawnOrNull();
+			return resident.getPrimaryTownOrNull().getSpawnOrNull();
 
 		return null;
     }
@@ -102,7 +102,7 @@ public class TownyAPI {
      */
     @Nullable
     public Town getResidentTownOrNull(Resident resident) {
-    	return resident.getTownOrNull();
+    	return resident.getPrimaryTownOrNull();
     }
     
     /**
@@ -114,7 +114,7 @@ public class TownyAPI {
     @Nullable
     public Nation getResidentNationOrNull(Resident resident) {
     	if (resident.hasNation())
-    		return resident.getTownOrNull().getNationOrNull();
+    		return resident.getPrimaryTownOrNull().getNationOrNull();
     	return null;
     }
     
@@ -898,7 +898,7 @@ public class TownyAPI {
 	public Town getTown(@NotNull Player player) {
 		Resident resident = getResident(player);
 		
-		return resident == null ? null : resident.getTownOrNull();
+		return resident == null ? null : resident.getPrimaryTownOrNull();
 	}
 	
 	@Nullable
@@ -922,7 +922,7 @@ public class TownyAPI {
 		final boolean isMayor = resident.hasPermissionNode(PermissionNodes.TOWNY_COMMAND_PLOT_ASMAYOR.getNode());
 
 		if (townBlock.hasResident()) {
-			final boolean isMayorInTheirOwnTown = isMayor && resident.hasTown() && resident.getTownOrNull() == townBlock.getTownOrNull();
+			final boolean isMayorInTheirOwnTown = isMayor && resident.hasTown() && resident.getPrimaryTownOrNull() == townBlock.getTownOrNull();
 			// Resident is either an admin, or the mayor (or equivalent) of the townblock, or the townblock's actual owner.
 			if (isAdmin || isMayorInTheirOwnTown || townBlock.hasResident(resident))
 				return;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -166,11 +166,11 @@ public class TownyFormatter {
 			screen.addComponentOf("lastonline", getResidentLastOnline(resident, translator));
 		
 		// Town: Camelot
-		String townLine = colourKeyValue(translator.of("status_town"), (!resident.hasTown() ? translator.of("status_no_town") : resident.getTownOrNull().getFormattedName() + formatPopulationBrackets(resident.getTownOrNull().getResidents().size()) ));
+		String townLine = colourKeyValue(translator.of("status_town"), (!resident.hasTown() ? translator.of("status_no_town") : resident.getPrimaryTownOrNull().getFormattedName() + formatPopulationBrackets(resident.getPrimaryTownOrNull().getResidents().size()) ));
 		if (!resident.hasTown())
 			screen.addComponentOf("town", townLine);
 		else {
-			Town town = resident.getTownOrNull();
+			Town town = resident.getPrimaryTownOrNull();
 			List<String> residents = getFormattedNames(town.getResidents());
 			if (residents.size() > 34)
 				shortenOverLengthList(residents, 35, translator);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownyMessaging.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownyMessaging.java
@@ -927,7 +927,7 @@ public class TownyMessaging {
 	 * @param message The translatable message to be sent to the resident and/or their town.
 	 */
 	public static void sendPrefixedTownMessage(Resident resident, Translatable message) {
-		Town town = resident.getTownOrNull();
+		Town town = resident.getPrimaryTownOrNull();
 		
 		if (town == null)
 			sendMsg(resident, message);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/TownySettings.java
@@ -1121,7 +1121,7 @@ public class TownySettings {
 	}
 
 	public static String getMayorPrefix(Resident resident) {
-		return resident.isMayor() ? resident.getTownOrNull().getTownLevel().mayorPrefix() : "";
+		return resident.isMayor() ? resident.getPrimaryTownOrNull().getTownLevel().mayorPrefix() : "";
 	}
 
 	public static String getCapitalPostfix(Town town) {
@@ -1185,7 +1185,7 @@ public class TownySettings {
 	}
 
 	public static String getMayorPostfix(Resident resident) {
-		return resident.isMayor() ? resident.getTownOrNull().getTownLevel().mayorPostfix() : "";
+		return resident.isMayor() ? resident.getPrimaryTownOrNull().getTownLevel().mayorPostfix() : "";
 	}
 
 	public static String getNPCPrefix() {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/chat/checks/KingCheck.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/chat/checks/KingCheck.java
@@ -19,7 +19,7 @@ public class KingCheck extends ChatCheck {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		Resident resident = townyUniverse.getResident(player.getUniqueId());
 		if(resident != null && resident.hasNation())
-			return resident.getTownOrNull().getNationOrNull().isKing(resident);
+			return resident.getPrimaryTownOrNull().getNationOrNull().isKing(resident);
 
 		return false;
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/chat/checks/MayorCheck.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/chat/checks/MayorCheck.java
@@ -19,7 +19,7 @@ public class MayorCheck extends ChatCheck {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		Resident resident = townyUniverse.getResident(player.getUniqueId()); 
 		if(resident != null && resident.hasTown())
-			return resident.getTownOrNull().isMayor(resident);
+			return resident.getPrimaryTownOrNull().isMayor(resident);
 			
 		return false;
 	}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/chat/types/TownType.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/chat/types/TownType.java
@@ -31,7 +31,7 @@ public class TownType extends ChatType {
 		if (resident == null || !resident.hasTown())
 			return recipients;
 		
-		final UUID town = resident.getTownOrNull().getUUID();
+		final UUID town = resident.getPrimaryTownOrNull().getUUID();
 
 		Collection<Player> newRecipients = new HashSet<>();
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/BaseCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/BaseCommand.java
@@ -282,7 +282,7 @@ public class BaseCommand implements TabCompleter{
 	protected static Town getTownFromResidentOrThrow(@NotNull Resident resident) throws TownyException {
 		if (!resident.hasTown())
 			throw new TownyException(Translatable.of("msg_err_townyobject_x_has_no_town", resident));
-		return resident.getTownOrNull();
+		return resident.getPrimaryTownOrNull();
 	}
 
 	@NotNull

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/NationCommand.java
@@ -2332,7 +2332,7 @@ public class NationCommand extends BaseCommand implements CommandExecutor {
 				if (!newKing.isMayor())
 					throw new TownyException(Translatable.of("msg_err_new_king_notmayor"));
 				
-				changeNationOwnership(sender, nation, getResidentOrThrow(split[1]).getTown(), admin);
+                               changeNationOwnership(sender, nation, getResidentOrThrow(split[1]).getPrimaryTown(), admin);
 			} catch (TownyException e) {
 				TownyMessaging.sendErrorMsg(sender, e.getMessage(sender));
 			}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/PlotCommand.java
@@ -417,9 +417,9 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 		if (playerIsAbleToJoinViaPlotClaim(resident, townBlock, town)) {
 			final List<WorldCoord> coords = selection;
 			Confirmation.runOnAccept(() -> {
-				try {
-					resident.setTown(town);
-				} catch (AlreadyRegisteredException ignored) {}
+                               try {
+                                       resident.addTown(town);
+                               } catch (AlreadyRegisteredException ignored) {}
 				try {
 					continuePlotClaimProcess(coords, resident, player);
 				} catch (TownyException e) {
@@ -534,7 +534,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 				(resident.hasPermissionNode(PermissionNodes.TOWNY_COMMAND_PLOT_ASMAYOR.getNode()) && town.hasResident(resident))
 				|| (resident.hasPermissionNode(PermissionNodes.TOWNY_COMMAND_PLOT_ASMAYORINUNOWNED.getNode()) && town.hasResident(resident) && !townBlock.hasResident())
 				) {
-				selection = AreaSelectionUtil.filterOwnedBlocks(resident.getTown(), selection); // Treat it as a mayor able to put their town's plots for sale.
+                               selection = AreaSelectionUtil.filterOwnedBlocks(resident.getPrimaryTown(), selection); // Treat it as a mayor able to put their town's plots for sale.
 				selection = AreaSelectionUtil.filterOutResidentBlocks(resident, selection); // Filter out any resident-owned plots.
 			} else {
 				selection = AreaSelectionUtil.filterOwnedBlocks(resident, selection); // Treat it as a resident putting their own plots up for sale.
@@ -808,7 +808,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 			(resident.hasPermissionNode(PermissionNodes.TOWNY_COMMAND_PLOT_ASMAYOR.getNode()) && town.hasResident(resident))
 			|| (resident.hasPermissionNode(PermissionNodes.TOWNY_COMMAND_PLOT_ASMAYORINUNOWNED.getNode()) && town.hasResident(resident) && !townBlock.hasResident())
 			) {
-			selection = AreaSelectionUtil.filterOwnedBlocks(resident.getTown(), selection); // Treat it as a mayor able to set their town's plots not for sale.
+                       selection = AreaSelectionUtil.filterOwnedBlocks(resident.getPrimaryTown(), selection); // Treat it as a mayor able to set their town's plots not for sale.
 		} else {
 			selection = AreaSelectionUtil.filterOwnedBlocks(resident, selection); // Treat it as a resident making their own plots not for sale.
 		}
@@ -1100,7 +1100,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 			
 			TownyMessaging.sendPrefixedTownMessage(townBlock.getTownOrNull(), message);
 			
-			if (!resident.hasTown() || (resident.hasTown() && townBlock.getTownOrNull() != resident.getTownOrNull()))
+			if (!resident.hasTown() || (resident.hasTown() && townBlock.getTownOrNull() != resident.getPrimaryTownOrNull()))
 				TownyMessaging.sendMsg(resident, message);
 			
 			BukkitTools.fireEvent(new PlotSetForSaleEvent(resident, townBlock.getPlotPrice(), townBlock));
@@ -1643,7 +1643,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 		
 		TownyMessaging.sendPrefixedTownMessage(town, message);
 		
-		if (!resident.hasTown() || resident.getTownOrNull() != town)
+		if (!resident.hasTown() || resident.getPrimaryTownOrNull() != town)
 			TownyMessaging.sendMsg(player, message);
 	}
 
@@ -1660,7 +1660,7 @@ public class PlotCommand extends BaseCommand implements CommandExecutor {
 
 		TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_player_made_group_not_for_sale", player.getName(), group.getName()));
 		
-		if (!resident.hasTown() || resident.getTownOrNull() != town)
+		if (!resident.hasTown() || resident.getPrimaryTownOrNull() != town)
 			TownyMessaging.sendMsg(player, Translatable.of("msg_player_made_group_not_for_sale", player.getName(), group.getName()));
 	}
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/ResidentCommand.java
@@ -412,7 +412,7 @@ public class ResidentCommand extends BaseCommand implements CommandExecutor {
 		if (newSplit[0].equalsIgnoreCase("pvp")) {
 			checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_RESIDENT_TOGGLE_PVP.getNode());
 			
-			Town town = resident.getTownOrNull();
+			Town town = resident.getPrimaryTownOrNull();
 			// Test to see if the pvp cooldown timer is active for the town this resident belongs to.
 			if (TownySettings.getPVPCoolDownTime() > 0 && town != null && !resident.isAdmin()) {
 				if (CooldownTimerTask.hasCooldown(town.getUUID().toString(), CooldownType.PVP))

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -675,7 +675,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		case "new", "create"-> parseTownNewCommand(player, split);
 		case "notforsale", "nfs"-> parseTownNotForSaleCommand(player);
 		case "online"-> parseTownOnlineCommand(player, subArg);
-		case "outlaw", "ban"-> parseTownOutlawCommand(player, subArg, false, getResidentOrThrow(player).getTown());
+               case "outlaw", "ban"-> parseTownOutlawCommand(player, subArg, false, getResidentOrThrow(player).getPrimaryTown());
 		case "outlawlist"-> townOutlawList(player, split);
 		case "outpost"-> townOutpost(player, subArg);
 		case "plotgrouplist"-> townPlotGroupList(player, split);
@@ -791,11 +791,11 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		Resident resident = getResidentOrThrow(player);
 
 		String received = Translatable.of("town_received_invites").forLocale(player)
-				.replace("%a", Integer.toString(resident.getTown().getReceivedInvites().size()))
-				.replace("%m", Integer.toString(InviteHandler.getReceivedInvitesMaxAmount(resident.getTown())));
+				.replace("%a", Integer.toString(resident.getPrimaryTown().getReceivedInvites().size()))
+				.replace("%m", Integer.toString(InviteHandler.getReceivedInvitesMaxAmount(resident.getPrimaryTown())));
 		String sent = Translatable.of("town_sent_invites").forLocale(player)
-				.replace("%a", Integer.toString(resident.getTown().getSentInvites().size()))
-				.replace("%m", Integer.toString(InviteHandler.getSentInvitesMaxAmount(resident.getTown())));
+				.replace("%a", Integer.toString(resident.getPrimaryTown().getSentInvites().size()))
+				.replace("%m", Integer.toString(InviteHandler.getSentInvitesMaxAmount(resident.getPrimaryTown())));
 
 		if (args.length == 0 || args[0].equalsIgnoreCase("help") || args[0].equalsIgnoreCase("?") ) {
 			checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWN_INVITE_SEE_HOME.getNode());
@@ -831,7 +831,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 	private void listTownSentInvites(Player player, String[] args, Resident resident, String sent) throws TownyException {
 		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWN_INVITE_LIST_SENT.getNode());
 
-		List<Invite> sentinvites = resident.getTown().getSentInvites();
+		List<Invite> sentinvites = resident.getPrimaryTown().getSentInvites();
 		int page = args.length > 0 ? MathUtil.getPositiveIntOrThrow(args[0]) : 1;
 		InviteCommand.sendInviteList(player, sentinvites, page, true);
 		TownyMessaging.sendMessage(player, sent);
@@ -840,7 +840,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 	private void removeAllTownSentInvites(Resident resident, Player player) throws TownyException {
 		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWN_INVITE_ADD.getNode());
 
-		for (final Invite invite : new ArrayList<>(resident.getTown().getSentInvites()))
+		for (final Invite invite : new ArrayList<>(resident.getPrimaryTown().getSentInvites()))
 			invite.decline(true);
 
 		TownyMessaging.sendMessage(player, Translatable.of("msg_all_of_your_towns_sent_invites_have_been_cancelled"));
@@ -849,7 +849,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 	private void parseTownInviteReceivedCommand(Player player, String[] args, Resident resident, String received) throws TownyException {
 		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWN_INVITE_LIST_RECEIVED.getNode());
 
-		List<Invite> receivedinvites = resident.getTown().getReceivedInvites();
+		List<Invite> receivedinvites = resident.getPrimaryTown().getReceivedInvites();
 		int page = args.length > 0 ? MathUtil.getPositiveIntOrThrow(args[0]) : 1;
 		InviteCommand.sendInviteList(player, receivedinvites, page, false);
 		TownyMessaging.sendMessage(player, received);
@@ -857,7 +857,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 	private void parseTownInviteAcceptCommand(Player player, String[] args, Resident resident) throws TownyException {
 		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWN_INVITE_ACCEPT.getNode());
-		Town town = resident.getTown();
+		Town town = resident.getPrimaryTown();
 		List<Invite> invites = town.getReceivedInvites();
 
 		if (invites.size() == 0)
@@ -889,7 +889,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 	private void parseTownInviteDenyCommand(Player player, String[] args, Resident resident) throws TownyException {
 		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWN_INVITE_DENY.getNode());
-		Town town = resident.getTown();
+		Town town = resident.getPrimaryTown();
 		List<Invite> invites = town.getReceivedInvites();
 
 		if (invites.size() == 0)
@@ -976,7 +976,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 		// Kick outlaws from town if they are residents.
 		if (town.hasResident(target)) {
-			target.removeTown();
+                       target.removeTown(town);
 			Object outlawer = (admin ? Translatable.of("admin_sing") : sender.getName());
 			TownyMessaging.sendMsg(target, Translatable.of("msg_kicked_by", outlawer));
 			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_kicked", outlawer, target.getName()));
@@ -1248,7 +1248,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		if (!admin) {
 			catchRuinedTown((Player) sender);
 			Resident resident = getResidentOrThrow(sender.getName());
-			town = resident.getTown();
+			town = resident.getPrimaryTown();
 			checkPermOrThrow(sender, PermissionNodes.TOWNY_COMMAND_TOWN_TOGGLE.getNode(split[0].toLowerCase(Locale.ROOT)));
 		}
 
@@ -1870,7 +1870,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		
 		if (!admin && player != null) {
 			resident = getResidentOrThrow(player);
-			town = resident.getTown();
+			town = resident.getPrimaryTown();
 		} else // Have the resident being tested be the mayor.
 			resident = town.getMayor();
 
@@ -2627,7 +2627,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 		town.setRegistered(System.currentTimeMillis());
 		town.setMapColorHexCode(TownySettings.getDefaultTownMapColor());
-		resident.setTown(town);
+               resident.addTown(town);
 		town.setMayor(resident, false);
 		town.setFounder(resident.getName());
 
@@ -2742,8 +2742,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		if (resident.isJailed() && resident.getJailTown().getUUID().equals(town.getUUID()))
 			JailUtil.unJailResident(resident, UnJailReason.LEFT_TOWN);
 
-		if (town.hasResident(resident))
-			resident.removeTown();
+               if (town.hasResident(resident))
+                       resident.removeTown(town);
 
 		TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_left_town", resident.getName()));
 		TownyMessaging.sendMsg(player, Translatable.of("msg_left_town", resident.getName()));
@@ -2874,7 +2874,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		if (town.hasOutlaw(resident))
 			town.removeOutlaw(resident);
 
-		resident.setTown(town);
+               resident.addTown(town);
 		plugin.deleteCache(resident);
 		resident.save();
 		town.save();
@@ -2917,7 +2917,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		checkPermOrThrow(player, PermissionNodes.TOWNY_COMMAND_TOWN_KICK.getNode());
 		catchRuinedTown(player);
 		Resident resident = getResidentOrThrow(player);
-		Town town = resident.getTown();
+		Town town = resident.getPrimaryTown();
 
 		townKickResidents(player, resident, town, ResidentUtil.getValidatedResidentsOfTown(player, town, names));
 
@@ -2969,8 +2969,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			// Remove any trust they have in the town or town's plots.
 			resToKick.removeTrustInTown(town);
 
-			// Finally kick the resident.
-			resToKick.removeTown();
+                       // Finally kick the resident.
+                       resToKick.removeTown(town);
 		} catch (TownyException e) {
 			TownyMessaging.sendErrorMsg(sender, e.getMessage(sender));
 			return false;
@@ -3961,7 +3961,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 			// If the town is still null, the resident has to have a town.
 			if (town == null)
-				town = resident.getTownOrNull();
+				town = resident.getPrimaryTownOrNull();
 
 			// Figure out how much to deposit or withdraw.
 			int amount;
@@ -4347,7 +4347,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 
 				Resident currentMayor = town.getMayor();
 				if (resident.equals(currentMayor)) {
-					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_town_buytown_already_mayor", resident.getTownOrNull().getName()));
+					TownyMessaging.sendErrorMsg(sender, Translatable.of("msg_town_buytown_already_mayor", resident.getPrimaryTownOrNull().getName()));
 					return;
 				}
 
@@ -4362,8 +4362,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				}
 				
 				try {
-					if (resident.hasTown())
-						resident.removeTown();
+                                       if (resident.hasTown())
+                                               resident.removeTown(resident.getPrimaryTownOrNull());
 					
 					townAddResident(town, resident);
 					town.setMayor(resident);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -1284,7 +1284,7 @@ public class TownyAdminCommand extends BaseCommand implements CommandExecutor {
 				throw new TownyException(Translatable.of("msg_err_townadmintownrank_wrong_town"));
 			if (resident.isMayor())
 				throw new TownyException(Translatable.of("msg_you_cannot_kick_this_resident", resident.getName()));
-			resident.removeTown();
+                       resident.removeTown(town);
 			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_kicked", "Console", resident.getName()));
 			TownyMessaging.sendMsg(sender, Translatable.of("msg_kicked", "You", resident.getName()));
 			if (resident.isOnline())

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownyCommand.java
@@ -182,7 +182,7 @@ public class TownyCommand extends BaseCommand implements CommandExecutor {
 						Resident resident = TownyAPI.getInstance().getResident(player);
 						
 						if (resident != null)
-							town = resident.getTownOrNull();
+							town = resident.getPrimaryTownOrNull();
 					}
 
 					for (String line : getTownyPrices(town, Translator.locale(sender)))

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -315,8 +315,9 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		for (Resident toCheck : toSave)
 			saveResident(toCheck);
 		
-		if (resident.hasTown() && resident.getTownOrNull() != null)
-			resident.removeTown();
+               if (resident.hasTown() && resident.getPrimaryTownOrNull() != null)
+                       for (Town t : new ArrayList<>(resident.getTowns()))
+                               resident.removeTown(t);
 
 		if (resident.hasUUID() && !resident.isNPC())
 			saveHibernatedResident(resident.getUUID(), resident.getRegistered());
@@ -430,8 +431,8 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 			town.getAccount().removeAccount();
 
 		for (Resident resident : toSave) {
-			ResidentModeHandler.resetModes(resident, false);
-			resident.removeTown(true);
+                       ResidentModeHandler.resetModes(resident, false);
+                       resident.removeTown(town, true);
 		}
 		
 		// Look for residents inside of this town's jail(s) and free them, more than 
@@ -852,8 +853,8 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 			}
 			
 			// Save the town if the player was the mayor.
-			if (resident.isMayor())
-				saveTown(resident.getTown());
+                       if (resident.isMayor())
+                               saveTown(resident.getPrimaryTown());
 			
 			// Make an oldResident with the previous name for use in searching friends/outlawlists/deleting the old resident file.
 			Resident oldResident = new Resident(oldName);
@@ -1203,15 +1204,15 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 		List<Resident> residents = new ArrayList<Resident>(mergeFrom.getResidents());
 		for (Resident resident : residents) {
 			try {
-				if (mergeInto.hasOutlaw(resident)) {
-					resident.removeTown();
-					continue;
-				}
+                               if (mergeInto.hasOutlaw(resident)) {
+                                       resident.removeTown(resident.getPrimaryTownOrNull());
+                                       continue;
+                               }
 				
 				List<String> nationRanks = new ArrayList<String>(resident.getNationRanks());
 				
-				resident.removeTown();
-				resident.setTown(mergeInto);
+                               resident.removeTown(resident.getPrimaryTownOrNull());
+                               resident.addTown(mergeInto);
 
 				if (isSameNation) {
 					for (String rank : nationRanks)

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -573,8 +573,8 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 						TownyMessaging.sendErrorMsg(Translation.of("flatfile_err_resident_tried_load_invalid_town", resident.getName(), line));
 					}
 					
-					if (town != null) {
-						resident.setTown(town, false);
+                                       if (town != null) {
+                                               resident.addTown(town, false);
 						
 						line = keys.get("title");
 						if (line != null)
@@ -2029,7 +2029,7 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 			list.add("about=" + resident.getAbout());
 
 		if (resident.hasTown()) {
-			list.add("town=" + resident.getTownOrNull().getName());
+			list.add("town=" + resident.getPrimaryTownOrNull().getName());
 			list.add("town-ranks=" + StringMgmt.join(resident.getTownRanksForSaving(), ","));
 			list.add("nation-ranks=" + StringMgmt.join(resident.getNationRanksForSaving(), ","));
 		}

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -735,12 +735,12 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 								universe.unregisterResident(olderRes);
 							} catch (NotRegisteredException ignored) {}
 							// Check if the older resident is a part of a town
-							if (olderRes.hasTown()) {
-								try {
-									// Resident#removeTown saves the resident, so we can't use it.
-									olderRes.getTown().removeResident(olderRes);
-								} catch (NotRegisteredException ignored) {}
-							}
+                                                       if (olderRes.hasTown()) {
+                                                               try {
+                                                                       // Resident#removeTown saves the resident, so we can't use it.
+                                                                       olderRes.getPrimaryTown().removeResident(olderRes);
+                                                               } catch (NotRegisteredException ignored) {}
+                                                       }
 							deleteResident(olderRes);					
 						} else {
 							TownyMessaging.sendDebugMsg("Deleting resident : " + resident.getName() + " which is a dupe of " + olderRes.getName());
@@ -850,13 +850,12 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 
 			line = rs.getString("town");
 			if ((line != null) && (!line.isEmpty())) {
-				Town town = universe.getTown(line);
-				if (town == null) {
-					TownyMessaging.sendErrorMsg("Loading Error: " + resident.getName() + " tried to load the town " + line + " which is invalid, removing town from the resident.");
-					resident.setTown(null, false);
-				}
-				else {
-					resident.setTown(town, false);
+                               Town town = universe.getTown(line);
+                               if (town == null) {
+                                       TownyMessaging.sendErrorMsg("Loading Error: " + resident.getName() + " tried to load the town " + line + " which is invalid, removing town from the resident.");
+                               }
+                               else {
+                                       resident.addTown(town, false);
 
 					try {
 						resident.setTitle(rs.getString("title"));
@@ -2311,9 +2310,9 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			
 			if (!TownySettings.getDefaultResidentAbout().equals(resident.getAbout()))
 				res_hm.put("about", resident.getAbout());
-			res_hm.put("town", resident.hasTown() ? resident.getTown().getName() : "");
-			res_hm.put("town-ranks", resident.hasTown() ? StringMgmt.join(resident.getTownRanksForSaving(), "#") : "");
-			res_hm.put("nation-ranks", resident.hasTown() ? StringMgmt.join(resident.getNationRanksForSaving(), "#") : "");
+                       res_hm.put("town", resident.hasTown() ? resident.getPrimaryTown().getName() : "");
+                       res_hm.put("town-ranks", resident.hasTown() ? StringMgmt.join(resident.getTownRanksForSaving(), "#") : "");
+                       res_hm.put("nation-ranks", resident.hasTown() ? StringMgmt.join(resident.getNationRanksForSaving(), "#") : "");
 			res_hm.put("friends", StringMgmt.join(resident.getFriends(), "#"));
 			res_hm.put("protectionStatus", resident.getPermissions().toString().replaceAll(",", "#"));
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/event/TownClaimEvent.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/event/TownClaimEvent.java
@@ -65,6 +65,6 @@ public class TownClaimEvent extends Event  {
 	 * @return the Town which claimed this TownBlock.
 	 */
 	public Town getTown() {
-		return resident.getTownOrNull();
+		return resident.getPrimaryTownOrNull();
 	}
 }

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/hooks/LuckPermsContexts.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/hooks/LuckPermsContexts.java
@@ -60,8 +60,8 @@ public class LuckPermsContexts implements ContextCalculator<Player> {
 		}, () -> Arrays.asList("true", "false"));
 		registerContext("towny:townrank", Resident::getTownRanks, TownyPerms::getTownRanks);
 		registerContext("towny:nationrank", Resident::getNationRanks, TownyPerms::getNationRanks);
-		registerContext("towny:istownconquered", resident -> Collections.singleton(String.valueOf(resident.hasTown() && resident.getTownOrNull().isConquered())), () -> Arrays.asList("true", "false"));
-		registerContext("towny:town", resident -> resident.hasTown() ? Collections.singleton(resident.getTownOrNull().getName()) : Collections.emptyList(), () -> TownyUniverse.getInstance().getTowns().stream().map(Town::getName).collect(Collectors.toSet()));
+		registerContext("towny:istownconquered", resident -> Collections.singleton(String.valueOf(resident.hasTown() && resident.getPrimaryTownOrNull().isConquered())), () -> Arrays.asList("true", "false"));
+		registerContext("towny:town", resident -> resident.hasTown() ? Collections.singleton(resident.getPrimaryTownOrNull().getName()) : Collections.emptyList(), () -> TownyUniverse.getInstance().getTowns().stream().map(Town::getName).collect(Collectors.toSet()));
 		registerContext("towny:nation", resident -> resident.hasNation() ? Collections.singleton(resident.getNationOrNull().getName()) : Collections.emptyList(), () -> TownyUniverse.getInstance().getNations().stream().map(Nation::getName).collect(Collectors.toSet()));
 	
 		this.calculators.removeIf(calculator -> !TownySettings.isContextEnabled(calculator.context));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/hooks/TownyPlaceholderExpansion.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/hooks/TownyPlaceholderExpansion.java
@@ -197,19 +197,19 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		switch (identifier) {
 		case "town": // %townyadvanced_town%
 			if (resident.hasTown())
-				town = String.format(TownySettings.getPAPIFormattingTown(), resident.getTownOrNull().getName());
+				town = String.format(TownySettings.getPAPIFormattingTown(), resident.getPrimaryTownOrNull().getName());
 			return StringMgmt.remUnderscore(town);
 		case "town_unformatted": // %townyadvanced_town_unformatted%
 			if (resident.hasTown())
-				town = resident.getTownOrNull().getName();
+				town = resident.getPrimaryTownOrNull().getName();
 			return town;
 		case "town_formatted": // %townyadvanced_town_formatted%
 			if (resident.hasTown())
-				town = String.format(TownySettings.getPAPIFormattingTown(), resident.getTownOrNull().getFormattedName());
+				town = String.format(TownySettings.getPAPIFormattingTown(), resident.getPrimaryTownOrNull().getFormattedName());
 			return StringMgmt.remUnderscore(town);
 		case "town_formatted_with_town_minimessage_colour": // %townyadvanced_town_formatted_with_town_minimessage_colour%
 			if (resident.hasTown()) {
-				Town residentTown = resident.getTownOrNull();
+				Town residentTown = resident.getPrimaryTownOrNull();
 				String townHexValue = residentTown.getMapColorHexCode();
 				if (townHexValue != null)
 					town = String.format(TownySettings.getPAPIFormattingTown(), "<#"+townHexValue+">" + residentTown.getFormattedName());
@@ -237,30 +237,30 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return StringMgmt.remUnderscore(nation);
 		case "town_balance": // %townyadvanced_town_balance%
 			if (resident.hasTown() && TownyEconomyHandler.isActive())
-				balance = getMoney(resident.getTownOrNull().getAccount().getCachedBalance());
+				balance = getMoney(resident.getPrimaryTownOrNull().getAccount().getCachedBalance());
 			return balance;
         case "town_balance_unformatted": // %townyadvanced_town_balance_unformatted%
 			if (resident.hasTown() && TownyEconomyHandler.isActive())
-				balance = String.valueOf(resident.getTownOrNull().getAccount().getCachedBalance());
+				balance = String.valueOf(resident.getPrimaryTownOrNull().getAccount().getCachedBalance());
             return balance;
 		case "nation_balance": // %townyadvanced_nation_balance%
 			if (resident.hasNation() && TownyEconomyHandler.isActive())
-				balance = getMoney(resident.getTownOrNull().getNationOrNull().getAccount().getCachedBalance());
+				balance = getMoney(resident.getPrimaryTownOrNull().getNationOrNull().getAccount().getCachedBalance());
 			return balance;
         case "nation_balance_unformatted": // %townyadvanced_nation_balance_unformatted%
 			if (resident.hasNation() && TownyEconomyHandler.isActive())
-				balance = String.valueOf(resident.getTownOrNull().getNationOrNull().getAccount().getCachedBalance());
+				balance = String.valueOf(resident.getPrimaryTownOrNull().getNationOrNull().getAccount().getCachedBalance());
             return balance;
 		case "town_tag": // %townyadvanced_town_tag%
 			if (resident.hasTown())
-				tag = String.format(TownySettings.getPAPIFormattingTown(), resident.getTownOrNull().getTag());
+				tag = String.format(TownySettings.getPAPIFormattingTown(), resident.getPrimaryTownOrNull().getTag());
 			return tag;
 		case "town_tag_override": // %townyadvanced_town_tag_override%
 			if (resident.hasTown()) {
-				if (resident.getTownOrNull().hasTag())
-					tag = String.format(TownySettings.getPAPIFormattingTown(), resident.getTownOrNull().getTag());
+				if (resident.getPrimaryTownOrNull().hasTag())
+					tag = String.format(TownySettings.getPAPIFormattingTown(), resident.getPrimaryTownOrNull().getTag());
 				else
-					tag = StringMgmt.remUnderscore(String.format(TownySettings.getPAPIFormattingTown(), resident.getTownOrNull().getName()));
+					tag = StringMgmt.remUnderscore(String.format(TownySettings.getPAPIFormattingTown(), resident.getPrimaryTownOrNull().getName()));
 			}
 			return tag;
 		case "nation_tag": // %townyadvanced_nation_tag%
@@ -279,8 +279,8 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return tag;
 		case "towny_tag": // %townyadvanced_towny_tag%
 			if (resident.hasTown()) {
-				if (resident.getTownOrNull().hasTag())
-					town = resident.getTownOrNull().getTag();
+				if (resident.getPrimaryTownOrNull().hasTag())
+					town = resident.getPrimaryTownOrNull().getTag();
 				if (resident.hasNation() && resident.getNationOrNull().hasTag())
 					nation = resident.getNationOrNull().getTag();
 			}
@@ -291,7 +291,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return tag;
 		case "towny_formatted": // %townyadvanced_towny_formatted%
 			if (resident.hasTown()) {
-				town = resident.getTownOrNull().getFormattedName();
+				town = resident.getPrimaryTownOrNull().getFormattedName();
 				if (resident.hasNation())
 					nation = resident.getNationOrNull().getFormattedName();
 			}
@@ -302,10 +302,10 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return tag;
 		case "towny_tag_formatted": // %townyadvanced_towny_tag_formatted%
 			if (resident.hasTown()) {
-				if (resident.getTownOrNull().hasTag())
-					town = resident.getTownOrNull().getTag();
+				if (resident.getPrimaryTownOrNull().hasTag())
+					town = resident.getPrimaryTownOrNull().getTag();
 				else
-					town = resident.getTownOrNull().getFormattedName();
+					town = resident.getPrimaryTownOrNull().getFormattedName();
 				if (resident.hasNation()) {
 					if (resident.getNationOrNull().hasTag())
 						nation = resident.getNationOrNull().getTag();
@@ -320,10 +320,10 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return tag;
 		case "towny_tag_override": // %townyadvanced_towny_tag_override%
 			if (resident.hasTown()) {
-				if (resident.getTownOrNull().hasTag())
-					town = resident.getTownOrNull().getTag();
+				if (resident.getPrimaryTownOrNull().hasTag())
+					town = resident.getPrimaryTownOrNull().getTag();
 				else
-					town = StringMgmt.remUnderscore(resident.getTownOrNull().getName());
+					town = StringMgmt.remUnderscore(resident.getPrimaryTownOrNull().getName());
 				if (resident.hasNation()) {
 					if (resident.getNationOrNull().hasTag())
 						nation = resident.getNationOrNull().getTag();
@@ -338,11 +338,11 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return tag;
 		case "towny_tag_override_with_minimessage_colour": // %townyadvanced_towny_tag_override_with_minimessage_colour%
 			if (resident.hasTown()) {
-				if (resident.getTownOrNull().hasTag())
-					town = resident.getTownOrNull().getTag();
+				if (resident.getPrimaryTownOrNull().hasTag())
+					town = resident.getPrimaryTownOrNull().getTag();
 				else
-					town = StringMgmt.remUnderscore(resident.getTownOrNull().getName());
-				String townHexColour = resident.getTownOrNull().getMapColorHexCode();
+					town = StringMgmt.remUnderscore(resident.getPrimaryTownOrNull().getName());
+				String townHexColour = resident.getPrimaryTownOrNull().getMapColorHexCode();
 				if (townHexColour != null)
 					town = "<#"+townHexColour+">" + town;
 
@@ -420,37 +420,37 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return colour;
 		case "town_residents_amount": // %townyadvanced_town_residents_amount%
 			if (resident.hasTown()) {
-				amount = String.valueOf(resident.getTownOrNull().getNumResidents());
+				amount = String.valueOf(resident.getPrimaryTownOrNull().getNumResidents());
 			}
 			return amount;
 		case "town_residents_online": // %townyadvanced_town_residents_online%
 			if (resident.hasTown()) {
-				amount = String.valueOf(TownyAPI.getInstance().getOnlinePlayers(resident.getTownOrNull()).size());
+				amount = String.valueOf(TownyAPI.getInstance().getOnlinePlayers(resident.getPrimaryTownOrNull()).size());
 			}
 			return amount;
 		case "town_townblocks_used": // %townyadvanced_town_townblocks_used%
 			if (resident.hasTown()) {
-				amount = String.valueOf(resident.getTownOrNull().getTownBlocks().size());
+				amount = String.valueOf(resident.getPrimaryTownOrNull().getTownBlocks().size());
 			}
 			return amount;
 		case "town_townblocks_bought": // %townyadvanced_town_townblocks_bought%
 			if (resident.hasTown()) {
-				amount = String.valueOf(resident.getTownOrNull().getPurchasedBlocks());
+				amount = String.valueOf(resident.getPrimaryTownOrNull().getPurchasedBlocks());
 			}
 			return amount;
 		case "town_townblocks_bonus": // %townyadvanced_town_townblocks_bonus%
 			if (resident.hasTown()) {
-				amount = String.valueOf(resident.getTownOrNull().getBonusBlocks());
+				amount = String.valueOf(resident.getPrimaryTownOrNull().getBonusBlocks());
 			}
 			return amount;
 		case "town_townblocks_maximum": // %townyadvanced_town_townblocks_maximum%
 			if (resident.hasTown()) {
-				amount = resident.getTownOrNull().getMaxTownBlocksAsAString();
+				amount = resident.getPrimaryTownOrNull().getMaxTownBlocksAsAString();
 			}
 			return amount;
 		case "town_townblocks_natural_maximum": // %townyadvanced_town_townblocks_natural_maximum%
 			if (resident.hasTown()) {
-				Town restown = resident.getTownOrNull();
+				Town restown = resident.getPrimaryTownOrNull();
 				amount = restown.hasUnlimitedClaims()
 					? restown.getMaxTownBlocksAsAString()
 					: String.valueOf(restown.getMaxTownBlocks() - restown.getBonusBlocks() - restown.getPurchasedBlocks());
@@ -458,7 +458,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return amount;
 		case "town_mayor": // %townyadvanced_town_mayor%
 			if (resident.hasTown()) {
-				name = resident.getTownOrNull().getMayor().getName();
+				name = resident.getPrimaryTownOrNull().getMayor().getName();
 			}
 			return name;
 		case "nation_king": // %townyadvanced_nation_king%
@@ -490,7 +490,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return String.valueOf(resident.getTaxOwing(true));
 		case "daily_town_upkeep": // %townyadvanced_daily_town_upkeep%
 			if (resident.hasTown()) {
-				cost = TownySettings.getTownUpkeepCost(resident.getTownOrNull());
+				cost = TownySettings.getTownUpkeepCost(resident.getPrimaryTownOrNull());
 			}
 			return getMoney(cost);
 		case "daily_town_per_plot_upkeep": // %townyadvanced_daily_town_per_plot_upkeep%
@@ -499,7 +499,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return getMoney(TownySettings.getUpkeepPenalty());
 		case "daily_town_upkeep_reduction_from_town_level": // %townyadvanced_daily_town_upkeep_reduction_from_town_level%
 			cost = resident.hasTown() 
-				? resident.getTownOrNull().getTownLevel().upkeepModifier()
+				? resident.getPrimaryTownOrNull().getTownLevel().upkeepModifier()
 				: 1.0;
 			return cost == 1.0 ? "0" : String.valueOf(dFormat.format((1.0 - cost) * 100));
 		case "daily_town_upkeep_reduction_from_nation_level": // %townyadvanced_daily_town_upkeep_reduction_from_nation_level%
@@ -521,8 +521,8 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return cost == 1.0 ? "0" : String.valueOf(dFormat.format((1.0 - cost) * 100));
 		case "daily_town_tax": // %townyadvanced_daily_town_tax%
 			if (resident.hasTown()) {
-				cost = resident.getTownOrNull().getTaxes();
-				percentage = resident.getTownOrNull().isTaxPercentage();
+				cost = resident.getPrimaryTownOrNull().getTaxes();
+				percentage = resident.getPrimaryTownOrNull().isTaxPercentage();
 			}
 			return String.valueOf(cost) + (percentage ? "%" : "");
 		case "daily_nation_tax": // %townyadvanced_daily_nation_tax%
@@ -555,7 +555,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return getMoney(TownySettings.getOutpostCost());
 		case "townblock_next_claim_price": // %townyadvanced_townblock_next_claim_price%
 			if (resident.hasTown())
-				cost = resident.getTownOrNull().getTownBlockCost();
+				cost = resident.getPrimaryTownOrNull().getTownBlockCost();
 			else
 				cost = TownySettings.getClaimPrice();
 			return getMoney(cost);
@@ -566,7 +566,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return String.valueOf(resident.hasNation());
 		case "nation_tag_town_formatted": // %townyadvanced_nation_tag_town_formatted%
 			if (resident.hasTown()) {
-				town = resident.getTownOrNull().getFormattedName();
+				town = resident.getPrimaryTownOrNull().getFormattedName();
 				if (resident.hasNation() && resident.getNationOrNull().hasTag())
 					nation = resident.getNationOrNull().getTag();
 			}
@@ -577,7 +577,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return tag;
 		case "nation_tag_town_name": // %townyadvanced_nation_tag_town_name%
 			if (resident.hasTown()) {
-				town = resident.getTownOrNull().getName();
+				town = resident.getPrimaryTownOrNull().getName();
 				if (resident.hasNation() && resident.getNationOrNull().hasTag())
 					nation = resident.getNationOrNull().getTag();
 			}
@@ -588,7 +588,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return tag;
 		case "town_map_color_hex": // %townyadvanced_town_map_color_hex%
 			if (resident.hasTown()){
-				hex = resident.getTownOrNull().getMapColorHexCode();
+				hex = resident.getPrimaryTownOrNull().getMapColorHexCode();
 				if (!hex.isEmpty())
 					hex = "#"+hex;
 			}
@@ -602,7 +602,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			return hex;
 		case "town_map_color_minimessage_hex": // %townyadvanced_town_map_color_minimessage_hex%
 			if (resident.hasTown()){
-				hex = resident.getTownOrNull().getMapColorHexCode();
+				hex = resident.getPrimaryTownOrNull().getMapColorHexCode();
 				if (!hex.isEmpty())
 					hex = "<#"+hex+">";
 			}
@@ -640,9 +640,9 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 			}
 			return tag;
 		case "town_prefix": // %townyadvanced_town_prefix%
-			return resident.hasTown() ? TownySettings.getTownPrefix(resident.getTownOrNull()) : "";
+			return resident.hasTown() ? TownySettings.getTownPrefix(resident.getPrimaryTownOrNull()) : "";
 		case "town_postfix": // %townyadvanced_town_postfix%
-			return resident.hasTown() ? TownySettings.getTownPostfix(resident.getTownOrNull()) : "";
+			return resident.hasTown() ? TownySettings.getTownPostfix(resident.getPrimaryTownOrNull()) : "";
 		case "nation_prefix": // %townyadvanced_nation_prefix%
 			return resident.hasNation() ? TownySettings.getNationPrefix(resident.getNationOrNull()) : "";
 		case "nation_postfix": // %townyadvanced_nation_postfix%
@@ -652,13 +652,13 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 		case "is_nation_peaceful": // %townyadvanced_is_nation_peaceful%	
 			return resident.hasNation() ? (resident.getNationOrNull().isNeutral() ? Translation.of("status_town_title_peaceful"): "") : "";
 		case "is_town_peaceful": // %townyadvanced_is_town_peaceful%	
-			return resident.hasTown() ? (resident.getTownOrNull().isNeutral() ? Translation.of("status_town_title_peaceful"): "") : "";
+			return resident.hasTown() ? (resident.getPrimaryTownOrNull().isNeutral() ? Translation.of("status_town_title_peaceful"): "") : "";
 		case "is_town_public": // %townyadvanced_is_town_public%
-			return resident.hasTown() ? (resident.getTownOrNull().isPublic() ? Translation.of("status_public") : "") : "";
+			return resident.hasTown() ? (resident.getPrimaryTownOrNull().isPublic() ? Translation.of("status_public") : "") : "";
 		case "is_town_open": // %townyadvanced_is_town_open%
-			return resident.hasTown() ? (resident.getTownOrNull().isOpen() ? Translation.of("status_title_open") : "") : "";
+			return resident.hasTown() ? (resident.getPrimaryTownOrNull().isOpen() ? Translation.of("status_title_open") : "") : "";
 		case "town_board": // %townyadvanced_town_board%
-			return resident.hasTown() ? resident.getTownOrNull().getBoard() : "";
+			return resident.hasTown() ? resident.getPrimaryTownOrNull().getBoard() : "";
 		case "nation_board": // %townyadvanced_nation_board%
 			return resident.hasTown() ? (resident.hasNation() ? resident.getNationOrNull().getBoard() : "") : "";
 		case "time_until_new_day_formatted": {// %townyadvanced_time_until_new_day_formatted%
@@ -686,7 +686,7 @@ public class TownyPlaceholderExpansion extends PlaceholderExpansion implements R
 				? ""
 				: resident.hasNation()
 					? String.format(TownySettings.getPAPIFormattingNation(), StringMgmt.remUnderscore(resident.getNationOrNull().getName()))
-					: String.format(TownySettings.getPAPIFormattingTown(), StringMgmt.remUnderscore(resident.getTownOrNull().getName()));
+					: String.format(TownySettings.getPAPIFormattingTown(), StringMgmt.remUnderscore(resident.getPrimaryTownOrNull().getName()));
 
 		case "resident_join_date_unformatted": // %townyadvanced_resident_join_date_unformatted%
 			return String.valueOf(resident.getRegistered());

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -1077,7 +1077,7 @@ public class TownyPlayerListener implements Listener {
 			return keepInventory;
 
 		if (resident.hasTown() && !keepInventory) {
-			Town town = resident.getTownOrNull();
+			Town town = resident.getPrimaryTownOrNull();
 			Town tbTown = tb.getTownOrNull();
 			// Sometimes we keep the inventory only when they are in their own town.
 			if (TownySettings.getKeepInventoryInOwnTown() && tbTown.equals(town))
@@ -1274,7 +1274,7 @@ public class TownyPlayerListener implements Listener {
 	}
 
 	public boolean blockWarPlayerCommand(Player player, Resident resident, String command) {
-		if (resident.hasTown() && resident.getTownOrNull().hasActiveWar() && blockedWarCommands.containsCommand(command)) {
+		if (resident.hasTown() && resident.getPrimaryTownOrNull().hasActiveWar() && blockedWarCommands.containsCommand(command)) {
 			TownyMessaging.sendErrorMsg(player, Translatable.of("msg_command_war_blocked"));
 			return true;
 		}
@@ -1341,7 +1341,7 @@ public class TownyPlayerListener implements Listener {
 			if (town.hasResident(resident) 
 				|| resident.hasPermissionNode(PermissionNodes.TOWNY_ADMIN_TOURIST_COMMAND_LIMITATION_BYPASS.getNode())
 				|| TownySettings.doTrustedResidentsBypassTownBlockedCommands() && town.hasTrustedResident(resident)
-				|| (resident.hasTown() && TownySettings.doAlliesBypassTownBlockedCommands() && CombatUtil.isAlly(town, resident.getTownOrNull())))
+				|| (resident.hasTown() && TownySettings.doAlliesBypassTownBlockedCommands() && CombatUtil.isAlly(town, resident.getPrimaryTownOrNull())))
 				return false;
 
 			TownyMessaging.sendErrorMsg(player, Translatable.of("msg_command_outsider_blocked", town.getName()));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Town.java
@@ -417,7 +417,7 @@ public class Town extends Government implements TownBlockOwner {
 		if (hasResident(resident))
 			throw new AlreadyRegisteredException(Translation.of("msg_err_already_in_town", resident.getName(), getFormattedName()));
 		
-		final Town residentTown = resident.getTownOrNull();
+		final Town residentTown = resident.getPrimaryTownOrNull();
 		if (residentTown != null && !this.equals(residentTown))
 			throw new AlreadyRegisteredException(Translation.of("msg_err_already_in_town", resident.getName(), residentTown.getFormattedName()));
 	}
@@ -1253,7 +1253,7 @@ public class Town extends Government implements TownBlockOwner {
 		if (hasOutlaw(resident))
 			throw new AlreadyRegisteredException(Translation.of("msg_err_resident_already_an_outlaw"));
 		
-		final Town residentTown = resident.getTownOrNull();
+		final Town residentTown = resident.getPrimaryTownOrNull();
 		if (this.equals(residentTown))
 			throw new AlreadyRegisteredException(Translation.of("msg_err_not_outlaw_in_your_town"));
 	}
@@ -1675,7 +1675,7 @@ public class Town extends Government implements TownBlockOwner {
 	}
 	
 	public boolean hasTrustedResident(Resident resident) {
-		Town residentsTown = resident.getTownOrNull();
+		Town residentsTown = resident.getPrimaryTownOrNull();
 		return trustedResidents.contains(resident) || (residentsTown != null && this.hasTrustedTown(residentsTown));
 	}
 	

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlock.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/TownBlock.java
@@ -653,7 +653,7 @@ public class TownBlock extends TownyObject {
 				|| (!hasMinTownMembershipDays() && !hasMaxTownMembershipDays()))
 			return;
 
-		Town residentTown = resident.getTownOrNull();
+		Town residentTown = resident.getPrimaryTownOrNull();
 		if (residentTown == null || !residentTown.equals(this.town))
 			return;
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/permissions/TownyPerms.java
@@ -278,7 +278,7 @@ public class TownyPerms {
 		Set<String> permList = new HashSet<>(getDefault());
 		
 		//Check for town membership
-		final Town town = resident.getTownOrNull();
+		final Town town = resident.getPrimaryTownOrNull();
 		if (town != null) {
 			permList.addAll(getTownDefault(town.getName().toLowerCase(Locale.ROOT)));
 			
@@ -321,8 +321,8 @@ public class TownyPerms {
 		LinkedHashMap<String, Boolean> newPerms = new LinkedHashMap<String, Boolean>();
 
 		for (String permission : playerPermArray) {
-			if (permission.contains("{townname}") && resident.getTownOrNull() != null)
-				permission = permission.replace("{townname}", resident.getTownOrNull().getName().toLowerCase(Locale.ROOT));
+			if (permission.contains("{townname}") && resident.getPrimaryTownOrNull() != null)
+				permission = permission.replace("{townname}", resident.getPrimaryTownOrNull().getName().toLowerCase(Locale.ROOT));
 			
 			if (permission.contains("{nationname}") && resident.getNationOrNull() != null)
 				permission = permission.replace("{nationname}", resident.getNationOrNull().getName().toLowerCase(Locale.ROOT));

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -519,7 +519,7 @@ public class DailyTimerTask extends TownyTimerTask {
 		if (!resident.isMayor()) {
 			TownyMessaging.sendMsg(resident, Translatable.of("msg_you_couldnt_pay_town_tax", prettyMoney(tax), town.getFormattedName()));
 			// remove this resident from the town, they cannot pay the town tax.
-			resident.removeTown();
+                       resident.removeTown(town);
 		}
 
 		return false;

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/OnPlayerLogin.java
@@ -64,7 +64,7 @@ public class OnPlayerLogin implements Runnable {
 
 		TownyPerms.assignPermissions(resident, player);
 
-		final Town town = resident.getTownOrNull();
+		final Town town = resident.getPrimaryTownOrNull();
 		if (town != null) {
 			Nation nation = resident.getNationOrNull();
 
@@ -197,9 +197,9 @@ public class OnPlayerLogin implements Runnable {
 		Town town = TownyUniverse.getInstance().getTown(TownySettings.getDefaultTownName());
 		if (town == null)
 			return;
-		try {
-			resident.setTown(town);
-		} catch (AlreadyRegisteredException ignore) {}
+               try {
+                       resident.addTown(town);
+               } catch (AlreadyRegisteredException ignore) {}
 	}
 	
 	/**

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/ResidentPurge.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/ResidentPurge.java
@@ -62,11 +62,11 @@ public class ResidentPurge implements Runnable {
 				if (townless && resident.hasTown())
 					continue;
 
-				if (removeTown && resident.hasTown()) {
-					resident.removeTown();
-					count++;
-					continue;
-				}
+                               if (removeTown && resident.hasTown()) {
+                                       resident.removeTown(resident.getPrimaryTownOrNull());
+                                       count++;
+                                       continue;
+                               }
 
 				count++;
 				townyUniverse.getDataSource().removeResident(resident);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/CombatUtil.java
@@ -683,7 +683,7 @@ public class CombatUtil {
 	public static boolean isEnemyTownBlock(Player player, WorldCoord worldCoord) {
 		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
 		if (resident != null && resident.hasTown() && worldCoord.hasTownBlock())
-			return CombatUtil.isEnemy(worldCoord.getTownOrNull(), resident.getTownOrNull());
+			return CombatUtil.isEnemy(worldCoord.getTownOrNull(), resident.getPrimaryTownOrNull());
 		return false;
 	}
 	

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/JailUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/JailUtil.java
@@ -160,7 +160,7 @@ public class JailUtil {
 		Town town = null;
 		switch (reason) {
 		case ESCAPE -> {
-			town = resident.getTownOrNull();
+			town = resident.getPrimaryTownOrNull();
 			
 			// First show a message to the resident, either by broadcasting to the resident's town or just the resident (if they have no town.)
 			if (town != null)
@@ -174,7 +174,7 @@ public class JailUtil {
 			unJailResident(resident);
 		}
 		case LEFT_TOWN -> {
-			town = resident.getTownOrNull();
+			town = resident.getPrimaryTownOrNull();
 			TownyMessaging.sendMsg(resident, Translatable.of("msg_you_have_been_freed_from_jail"));
 			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_player_escaped_jail_by_leaving_town", resident.getName()));
 			unJailResident(resident);

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/PlayerCacheUtil.java
@@ -236,15 +236,15 @@ public class PlayerCacheUtil {
 			return TownBlockStatus.TOWN_RESIDENT;
 		
 		// Nation group.
-		if (TownySettings.areConqueredTownsGivenNationPlotPerms() && CombatUtil.isSameNation(town, resident.getTownOrNull()))
+		if (TownySettings.areConqueredTownsGivenNationPlotPerms() && CombatUtil.isSameNation(town, resident.getPrimaryTownOrNull()))
 			return TownBlockStatus.TOWN_NATION;
 		
 		// Ally group.
-		if (CombatUtil.isAlly(town, resident.getTownOrNull()))
+		if (CombatUtil.isAlly(town, resident.getPrimaryTownOrNull()))
 			return TownBlockStatus.TOWN_ALLY;
 		
 		// Enemy.
-		if (CombatUtil.isEnemy(resident.getTownOrNull(), town))
+		if (CombatUtil.isEnemy(resident.getPrimaryTownOrNull(), town))
 			return TownBlockStatus.ENEMY;
 
 		// Nothing left but Outsider.

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ResidentUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/ResidentUtil.java
@@ -283,8 +283,8 @@ public class ResidentUtil {
 			i++;
 		}
 		
-		if (!toRemove.isEmpty())
-			toRemove.stream().forEach(res -> res.removeTown());
+               if (!toRemove.isEmpty())
+                       toRemove.forEach(res -> res.removeTown(town));
 	}
 	
 

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/SpawnUtil.java
@@ -79,7 +79,7 @@ public class SpawnUtil {
 
 		// Set up town and nation variables.
 		final Town town = switch (spawnType) {
-			case RESIDENT -> resident.getTownOrNull();
+			case RESIDENT -> resident.getPrimaryTownOrNull();
 			case TOWN -> (Town) townyObject;
 			default -> null;
 		};
@@ -288,11 +288,11 @@ public class SpawnUtil {
 			// Arguments were used.
 			if (TownySettings.trustedResidentsGetToSpawnToTown() && 
 					(town.hasTrustedResident(resident) || 
-							(resident.hasTown() && town.hasTrustedTown(resident.getTownOrNull())))) {
+							(resident.hasTown() && town.hasTrustedTown(resident.getPrimaryTownOrNull())))) {
 				townSpawnLevel = TownSpawnLevel.TOWN_RESIDENT;
 			} else if (!resident.hasTown()) {
 				townSpawnLevel = TownSpawnLevel.UNAFFILIATED;
-			} else if (resident.getTownOrNull() == town) {
+			} else if (resident.getPrimaryTownOrNull() == town) {
 				townSpawnLevel = outpost ? TownSpawnLevel.TOWN_RESIDENT_OUTPOST : TownSpawnLevel.TOWN_RESIDENT;
 			} else if (resident.hasNation() && town.hasNation()) {
 				Nation playerNation = resident.getNationOrNull();
@@ -664,11 +664,11 @@ public class SpawnUtil {
 					throw new TownyException(Translatable.of("msg_err_x_spawn_disallowed_from_x", "RTP", Translatable.of("msg_a_town_you_are_outlawed_in")));
 				if (resident.hasTown() && townAtPlayerLoc.hasNation()) {
 					Nation townLocNation = townAtPlayerLoc.getNationOrNull();
-					if (townLocNation.hasSanctionedTown(resident.getTownOrNull()))
+					if (townLocNation.hasSanctionedTown(resident.getPrimaryTownOrNull()))
 						throw new TownyException(Translatable.of("msg_err_cannot_nation_spawn_your_town_is_sanctioned", townLocNation.getName()));
 				}
 				if (resident.hasNation() && townAtPlayerLoc.hasNation()) {
-					if (CombatUtil.isEnemy(resident.getTownOrNull(), townAtPlayerLoc) && disallowedZones.contains("enemy"))
+					if (CombatUtil.isEnemy(resident.getPrimaryTownOrNull(), townAtPlayerLoc) && disallowedZones.contains("enemy"))
 						throw new TownyException(Translatable.of("msg_err_x_spawn_disallowed_from_x", spawnType.typeName(), Translatable.of("msg_enemy_areas")));
 					Nation townLocNation = townAtPlayerLoc.getNationOrNull();
 					Nation resNation = resident.getNationOrNull();
@@ -859,7 +859,7 @@ public class SpawnUtil {
 	 * @return bed spawn OR town spawn OR last world spawn
 	 */
 	private static CompletableFuture<Location> getIdealLocation(Resident resident) {
-		Town town = resident.getTownOrNull();
+		Town town = resident.getPrimaryTownOrNull();
 		Location loc = resident.getPlayer().getWorld().getSpawnLocation();
 
 		if (town != null && town.hasSpawn())

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/utils/TownRuinUtil.java
@@ -95,9 +95,9 @@ public class TownRuinUtil {
 		
 		//Set NPC mayor, otherwise mayor of ruined town cannot leave until full deletion 
 		Resident resident = ResidentUtil.createAndGetNPCResident();
-		try {
-			resident.setTown(town);
-		} catch (AlreadyRegisteredException ignored) {}
+               try {
+                       resident.addTown(town);
+               } catch (AlreadyRegisteredException ignored) {}
 		resident.save();
 		setMayor(town, resident);
 		town.setHasUpkeep(false);
@@ -150,7 +150,7 @@ public class TownRuinUtil {
 	public static void processRuinedTownReclaimRequest(Player player) {
 		try {
 			final Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
-			final Town town = resident != null ? resident.getTownOrNull() : null;
+			final Town town = resident != null ? resident.getPrimaryTownOrNull() : null;
 
 			if (town == null)
 				throw new TownyException(Translatable.of("msg_err_dont_belong_town"));
@@ -213,7 +213,7 @@ public class TownRuinUtil {
 		town.setMayor(newMayor);
 		if (oldMayor != null && oldMayor.isNPC()) {
 			// Delete the resident if the old mayor was an NPC.
-			oldMayor.removeTown();
+                       oldMayor.removeTown(town);
 			TownyUniverse.getInstance().getDataSource().removeResident(oldMayor);
 			// set upkeep again
 			town.setHasUpkeep(true);

--- a/Towny/src/main/java/com/palmergames/bukkit/util/DrawSmokeTaskFactory.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/util/DrawSmokeTaskFactory.java
@@ -36,7 +36,7 @@ public class DrawSmokeTaskFactory {
 	}
 
 	public static Color getAffiliationColor(Resident resident, WorldCoord coord) {
-		Town residentTown = resident.getTownOrNull();
+		Town residentTown = resident.getPrimaryTownOrNull();
 		Town town = coord.getTownOrNull();
 
 		if (residentTown == null || town == null)


### PR DESCRIPTION
## Summary
- allow each Resident to store multiple towns
- add helper methods for managing the towns list
- update database and command logic for new API

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876726190f48329baee0988ad2f238e